### PR TITLE
Refactor drugwars to companies

### DIFF
--- a/drugwars/classes.py
+++ b/drugwars/classes.py
@@ -67,45 +67,45 @@ class Bank:
             return False
 
 class Stash:
-    """Storage for excess drugs not carried in the coat."""
+    """Storage for excess shares not carried in the coat."""
 
     def __init__(self, player):
         self.player = player
-        self.cocaine = 0
-        self.heroin = 0
-        self.acid = 0
-        self.weed = 0
-        self.speed = 0
-        self.ludes = 0
+        self.acme = 0
+        self.globex = 0
+        self.initech = 0
+        self.umbrella = 0
+        self.cyberdyne = 0
+        self.soylent = 0
 
-    def withdraw(self, drug, amount):
-        if hasattr(self.player, drug):
-            dref = getattr(self.player, drug)
-            dref += amount
-            setattr(self.player, drug, dref)
-            sref = getattr(self, drug)
+    def withdraw(self, company, amount):
+        if hasattr(self.player, company):
+            pref = getattr(self.player, company)
+            pref += amount
+            setattr(self.player, company, pref)
+            sref = getattr(self, company)
             sref -= amount
-            setattr(self, drug, sref)
+            setattr(self, company, sref)
 
-    def transfer(self, drug, amount):
-        if hasattr(self.player, drug):
-            dref = getattr(self.player, drug)
-            dref -= amount
-            setattr(self.player, drug, dref)
-            sref = getattr(self, drug)
+    def transfer(self, company, amount):
+        if hasattr(self.player, company):
+            pref = getattr(self.player, company)
+            pref -= amount
+            setattr(self.player, company, pref)
+            sref = getattr(self, company)
             sref += amount
-            setattr(self, drug, sref)
+            setattr(self, company, sref)
     
-    def can_transfer(self, drug, amount):
-        if hasattr(self.player, drug):
-            dref = getattr(self.player, drug)
-            return dref >= amount
+    def can_transfer(self, company, amount):
+        if hasattr(self.player, company):
+            pref = getattr(self.player, company)
+            return pref >= amount
         return False
 
-    def can_withdraw(self, drug, amount):
-        if hasattr(self, drug):
-            dref = getattr(self, drug)
-            return dref >= amount
+    def can_withdraw(self, company, amount):
+        if hasattr(self, company):
+            pref = getattr(self, company)
+            return pref >= amount
         return False
 
 class Player:
@@ -119,92 +119,92 @@ class Player:
         self.days_end = 30
         self.health = 20
         self.max_trench = 100
-        self.cocaine = 0
-        self.heroin = 0
-        self.acid = 0
-        self.weed = 0
-        self.speed = 0
-        self.ludes = 0
+        self.acme = 0
+        self.globex = 0
+        self.initech = 0
+        self.umbrella = 0
+        self.cyberdyne = 0
+        self.soylent = 0
         self.bank = Bank(self)
         self.stash = Stash(self)
         self.shark = Shark(self)
         self.current_area = "Bronx"
     
-    def buy(self, drug, amount, price):
-        dref = getattr(self, drug)
-        dref += amount
-        setattr(self, drug, dref)
+    def buy(self, company, amount, price):
+        pref = getattr(self, company)
+        pref += amount
+        setattr(self, company, pref)
         self.money -= (amount * price)
 
     def len_inventory(self):
-        return (self.cocaine + self.heroin + self.acid + self.weed + self.speed + self.ludes)
+        return (self.acme + self.globex + self.initech + self.umbrella + self.cyberdyne + self.soylent)
 
     def coat_space(self):
-        return self.max_trench - (self.cocaine + self.heroin + self.acid + self.weed + self.speed + self.ludes)
+        return self.max_trench - (self.acme + self.globex + self.initech + self.umbrella + self.cyberdyne + self.soylent)
     
-    def get_max(self, drug, price):
+    def get_max(self, company, price):
         max_amt = int(round_down(self.money / price))
         if max_amt > self.coat_space():
             return self.coat_space()
         else:
             return max_amt
 
-    def get_max_sell(self, drug):
-        if drug == 'cocaine':
-            return self.cocaine
-        elif drug == 'heroin':
-            return self.heroin
-        elif drug == 'acid':
-            return self.acid
-        elif drug == 'weed':
-            return self.weed
-        elif drug == 'speed':
-            return self.speed
-        elif drug == 'ludes':
-            return self.ludes
+    def get_max_sell(self, company):
+        if company == 'acme':
+            return self.acme
+        elif company == 'globex':
+            return self.globex
+        elif company == 'initech':
+            return self.initech
+        elif company == 'umbrella':
+            return self.umbrella
+        elif company == 'cyberdyne':
+            return self.cyberdyne
+        elif company == 'soylent':
+            return self.soylent
 
     def can_buy(self, price, amount):
         return self.money >= (price * amount) and (self.len_inventory() + amount) <= self.max_trench
 
-    def can_sell(self, amount, drug):
-        dref = getattr(self, drug)
-        return dref - amount >= 0
+    def can_sell(self, amount, company):
+        pref = getattr(self, company)
+        return pref - amount >= 0
 
-    def get_amt(self, drug):
-        if hasattr(self, drug):
-            return getattr(self, drug)
+    def get_amt(self, company):
+        if hasattr(self, company):
+            return getattr(self, company)
         return None
 
-    def sell(self, drug, amount, price):
-        dref = getattr(self, drug)
-        dref -= amount
-        setattr(self, drug, dref)
+    def sell(self, company, amount, price):
+        pref = getattr(self, company)
+        pref -= amount
+        setattr(self, company, pref)
         self.money += (amount * price)
 
-class Prices:
-    """Generate random drug prices and market events."""
+class CompanyPrices:
+    """Generate random share prices and place events."""
 
     def __init__(self, player):
         seed(randint(-10000, 10000))
         self.player = player
-        self.cocaine = randint(15000, 29999)
-        self.heroin = randint(5000, 13999)
-        self.acid = randint(1000, 4999)
-        self.weed = randint(300, 899)
-        self.speed = randint(90, 249)
-        self.ludes = randint(10, 89)
+        self.acme = randint(15000, 29999)
+        self.globex = randint(5000, 13999)
+        self.initech = randint(1000, 4999)
+        self.umbrella = randint(300, 899)
+        self.cyberdyne = randint(90, 249)
+        self.soylent = randint(10, 89)
         self.actions = []
         events = [
-            lambda self: self.cops_bust_cocaine(),
-            lambda self: self.addicts_buy_coke(),
-            lambda self: self.cops_bust_heroin(),
-            lambda self: self.addicts_buy_herion(),
-            lambda self: self.cheap_acid(),
-            lambda self: self.cheap_cocaine(),
-            lambda self: self.cheap_heroin(),
-            lambda self: self.cheap_ludes(),
-            lambda self: self.cheap_speed(),
-            lambda self: self.cheap_weed(),
+            lambda self: self.regulators_probe_acme(),
+            lambda self: self.investors_buy_acme(),
+            lambda self: self.regulators_probe_globex(),
+            lambda self: self.investors_buy_globex(),
+            lambda self: self.cheap_initech(),
+            lambda self: self.cheap_acme(),
+            lambda self: self.cheap_globex(),
+            lambda self: self.cheap_soylent(),
+            lambda self: self.cheap_cyberdyne(),
+            lambda self: self.cheap_umbrella(),
         ]
         shuffle(events)
         self.action = None
@@ -218,52 +218,52 @@ class Prices:
         if len(self.actions) > 0:
             self.action = self.actions[0]
     
-    def cops_bust_cocaine(self):
+    def regulators_probe_acme(self):
         if 1 == randint(1, 35):
-            self.cocaine *= 2
-            self.actions.append("** Cops raided a coke house! Prices are rising!!! **")
+            self.acme *= 2
+            self.actions.append("** Regulators investigated Acme! Shares are rising!! **")
 
-    def addicts_buy_coke(self):
+    def investors_buy_acme(self):
         if 1 == randint(1, 35):
-            self.cocaine *= 4
-            self.actions.append("** Cokeheads everywhere are ready to pay. Prices are skyrocketing!! **")
+            self.acme *= 4
+            self.actions.append("** Investors are hyped about Acme. Shares are skyrocketing!! **")
 
-    def cops_bust_heroin(self):
+    def regulators_probe_globex(self):
         if 1 == randint(1, 25):
-            self.heroin *= 2
-            self.actions.append("** Cops raided a heroin kingpin's warehouse! Prices are rising!!! **")
+            self.globex *= 2
+            self.actions.append("** Regulators hit Globex headquarters! Shares are rising!!! **")
 
-    def addicts_buy_herion(self):
+    def investors_buy_globex(self):
         if 1 == randint(1, 35):
-            self.heroin *= 4
-            self.actions.append("** Heroin junkies everywhere need their fix. Prices are skyrocketing!! **")
+            self.globex *= 4
+            self.actions.append("** Traders everywhere want Globex. Shares are skyrocketing!! **")
     
-    def cheap_acid(self):
+    def cheap_initech(self):
         if 1 == randint(1, 25):
-            self.acid /= 4
-            self.actions.append("** Somebody found a reliable method for making acid. It's super cheap! **")
+            self.initech /= 4
+            self.actions.append("** Initech discovered a cost-cutting breakthrough. Shares are cheap! **")
     
-    def cheap_ludes(self):
+    def cheap_soylent(self):
         if 1 == randint(1, 20):
-            self.ludes /= 4
-            self.actions.append("** The pharmacy got robbed! Ludes are extremely cheap **")
+            self.soylent /= 4
+            self.actions.append("** Soylent factory fiasco! Shares are extremely cheap **")
     
-    def cheap_weed(self):
+    def cheap_umbrella(self):
         if 1 == randint(1, 20):
-            self.weed /= 4
-            self.actions.append("** Hempfest time! Weed is basically being handed out! **")
+            self.umbrella /= 4
+            self.actions.append("** Umbrella giveaway promotion! Shares are practically free! **")
 
-    def cheap_heroin(self):
+    def cheap_globex(self):
         if 1 == randint(1, 35):
-            self.heroin /= 4
-            self.actions.append("** Heroin markets are flooded! Prices have dropped!! **")
+            self.globex /= 4
+            self.actions.append("** Globex shares flood the place! Prices have dropped!! **")
 
-    def cheap_cocaine(self):
+    def cheap_acme(self):
         if 1 == randint(1, 40):
-            self.cocaine /= 4
-            self.actions.append("** Holy shit! You found a time machine to the 80s. Coke is cheap! **")
+            self.acme /= 4
+            self.actions.append("** Retro comeback for Acme! Shares are on sale! **")
 
-    def cheap_speed(self):
+    def cheap_cyberdyne(self):
         if 1 == randint(1, 20):
-            self.speed /= 4
-            self.actions.append("** Speed markets are flooded! Prices are dropping! **")
+            self.cyberdyne /= 4
+            self.actions.append("** Cyberdyne expansion stalls. Shares are dropping! **")

--- a/drugwars/events.py
+++ b/drugwars/events.py
@@ -6,10 +6,10 @@ from .helpers import (
     clear,
     round_down,
     check_ans_bsj,
-    check_drug_inp,
+    check_company_inp,
     get_price,
 )
-from .classes import Prices
+from .classes import CompanyPrices
 from random import randint, choice
 
 
@@ -52,13 +52,13 @@ def cops_chase(player):
                 aout = check_ans_yn(a)
                 if aout == 1:
                     if 1 == randint(1,3):
-                        drug = choice(["cocaine", "heroin", "acid", "weed", "speed", "ludes"])
-                        pdrug = player.get_amt(drug)
-                        if pdrug > 0:
+                        company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                        pc = player.get_amt(company)
+                        if pc > 0:
                             amnt = randint(1, 10)
-                            pdrug -= amnt
+                            pc -= amnt
                             clear()
-                            print(SingleTable([["You got away but you dropped " + str(amnt) + " bags of " + drug.capitalize() + " while running!!"]]).table)
+                            print(SingleTable([["You got away but you dropped " + str(amnt) + " shares of " + company.capitalize() + " while running!!"]]).table)
                         else:
                             print(SingleTable([["You got away!"]]).table)
                         input("Press ENTER to Continue")
@@ -69,13 +69,13 @@ def cops_chase(player):
                             clear()
                             print(SingleTable([["You got hit by one of their shots and lost some health!"]]).table)
                         else:
-                            drug = choice(["cocaine", "heroin", "acid", "weed", "speed", "ludes"])
-                            pdrug = player.get_amt(drug)
-                            if pdrug > 0:
+                            company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                            pc = player.get_amt(company)
+                            if pc > 0:
                                 amnt = randint(1, 10)
-                                pdrug -= amnt
+                                pc -= amnt
                                 clear()
-                                print(SingleTable([["You got away but you dropped " + str(amnt) + " bags of " + drug.capitalize() + " while running!!"]]).table)
+                                print(SingleTable([["You got away but you dropped " + str(amnt) + " shares of " + company.capitalize() + " while running!!"]]).table)
                             else:
                                 print(SingleTable([["You got away!"]]).table)
                             input("Press ENTER to Continue")
@@ -84,13 +84,13 @@ def cops_chase(player):
                     if 1 == randint(1,6):
                         cops -= 1
                         if cops == 0:
-                            drug = choice(["cocaine", "heroin", "acid", "weed", "speed", "ludes"])
-                            pdrug = player.get_amt(drug)
-                            if pdrug > 0:
+                            company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                            pc = player.get_amt(company)
+                            if pc > 0:
                                 amnt = randint(1, 10)
-                                pdrug -= amnt
+                                pc -= amnt
                                 clear()
-                                print(SingleTable([["You got away but you dropped " + str(amnt) + " bags of " + drug.capitalize() + " while running!!"]]).table)
+                                print(SingleTable([["You got away but you dropped " + str(amnt) + " shares of " + company.capitalize() + " while running!!"]]).table)
                             else:
                                 print(SingleTable([["You got away!"]]).table)
                             input("Press ENTER to Continue")
@@ -106,13 +106,13 @@ def cops_chase(player):
                 print(SingleTable([["Press ENTER to Try and Run"], ["HP: " + str(player.health) + "/ 20"]]).table)
                 input()
                 if 1 == randint(1,3):
-                    drug = choice(["cocaine", "heroin", "acid", "weed", "speed", "ludes"])
-                    pdrug = player.get_amt(drug)
-                    if pdrug > 0:
+                    company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                    pc = player.get_amt(company)
+                    if pc > 0:
                         amnt = randint(1, 10)
-                        pdrug -= amnt
+                        pc -= amnt
                         clear()
-                        print(SingleTable([["You got away but you dropped " + str(amnt) + " bags of " + drug.capitalize() + " while running!!"]]).table)
+                        print(SingleTable([["You got away but you dropped " + str(amnt) + " shares of " + company.capitalize() + " while running!!"]]).table)
                     else:
                         print(SingleTable([["You got away!"]]).table)
                     input("Press ENTER to Continue")
@@ -163,7 +163,7 @@ def ask_stash(player):
 
     clear()
     while True:
-        print(SingleTable([['Would you like to stash any drugs?']]).table)
+        print(SingleTable([['Would you like to stash any shares?']]).table)
         ans = input("\n> ")
         aout = check_ans_yn(ans)
         if aout == 1:
@@ -175,9 +175,9 @@ def ask_stash(player):
             break
 
 def visit_stash(player):
-    """Interactively deposit to or withdraw drugs from the stash."""
+    """Interactively deposit to or withdraw shares from the stash."""
 
-    stashes = ["cocaine", "heroin", "acid", "weed", "speed", "ludes"]
+    stashes = ["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"]
     for stash in stashes:
         clear()
         while True:
@@ -322,7 +322,7 @@ def upgrade_coat(p):
     while True:
         price = randint(150, 250)
         if p.money >= price:
-            print(SingleTable([["** Would you like to buy 15 more pockets for more drugs? It's $" + str(price) + " **"], ["Wallet: ", p.money]]).table)
+            print(SingleTable([["** Would you like to buy 15 more pockets for more shares? It's $" + str(price) + " **"], ["Wallet: ", p.money]]).table)
             a = input("\n> ")
             ao = check_ans_yn(a)
             if ao == 1:
@@ -354,35 +354,35 @@ def get_mugged(p):
         input("Press ENTER to Continue")
         clear()
 
-def find_drugs(p):
-    """Chance to discover random drugs on the ground."""
+def find_companies(p):
+    """Chance to discover random shares on the ground."""
 
     clear()
     if 1 == randint(1, 10):
         clear()
         amnt = randint(1, 10)
-        drug = randint(1, 8)
-        dstr = ""
+        choice_num = randint(1, 6)
+        cstr = ""
         if p.len_inventory() + amnt <= p.max_trench:
-            if drug == 1:
-                dstr = "Cocaine"
-                p.cocaine += amnt
-            if drug == 2:
-                dstr = "Heroin"
-                p.heroin += amnt
-            if drug == 3:
-                dstr = "Acid"
-                p.acid += amnt
-            if drug == 4:
-                dstr = "Weed"
-                p.weed += amnt
-            if drug == 5:
-                dstr = "Speed"
-                p.speed += amnt
-            if drug == 6:
-                dstr = "Ludes"
-                p.ludes += amnt
-            print(SingleTable([["You found " + str(amnt) + " bags of " + dstr + " on the ground... \n FUCK YEAH"]]).table)
+            if choice_num == 1:
+                cstr = "Acme"
+                p.acme += amnt
+            if choice_num == 2:
+                cstr = "Globex"
+                p.globex += amnt
+            if choice_num == 3:
+                cstr = "Initech"
+                p.initech += amnt
+            if choice_num == 4:
+                cstr = "Umbrella"
+                p.umbrella += amnt
+            if choice_num == 5:
+                cstr = "Cyberdyne"
+                p.cyberdyne += amnt
+            if choice_num == 6:
+                cstr = "Soylent"
+                p.soylent += amnt
+            print(SingleTable([["You found " + str(amnt) + " shares of " + cstr + " on the ground... \n NICE"]]).table)
             input("Press ENTER to Continue")
 
 def buy_gun(p):
@@ -436,7 +436,7 @@ def you_win(p):
     exit()
 
 def buy_menu(prices, inventory_table, pricing_table, money_table, p):
-    """Prompt the player to purchase drugs."""
+    """Prompt the player to purchase shares."""
 
     while True:
         print(SingleTable(inventory_table()).table)
@@ -444,14 +444,14 @@ def buy_menu(prices, inventory_table, pricing_table, money_table, p):
         print(SingleTable(money_table(), title="Money").table)
         print(SingleTable([["What would you like to buy?"]]).table)
         desired = input("\n> ")
-        if not check_drug_inp(desired):
+        if not check_company_inp(desired):
             clear()
-            print(SingleTable([["Enter the first letter of a drug to choose!"]]).table)
+            print(SingleTable([["Enter the first letter of a company to choose!"]]).table)
         else:
             # Get some useful variables that will clean up the code a lot
-            drug = check_drug_inp(desired)
-            price = round_down(get_price(prices, drug))
-            max_allowed = p.get_max(drug, price)
+            company = check_company_inp(desired)
+            price = round_down(get_price(prices, company))
+            max_allowed = p.get_max(company, price)
             
             print(SingleTable([["How much would you like to buy?"], [f"Max Allowed: {str(max_allowed)}"]]).table)
             desiredamnt = input("\n> ")
@@ -477,11 +477,11 @@ def buy_menu(prices, inventory_table, pricing_table, money_table, p):
                         print(SingleTable([["That isn't a valid amount!"]]).table)
                         continue
             
-            # Buy the drug
+            # Buy the company
             if p.can_buy(price, amnt):
-                p.buy(drug, amnt, price)
+                p.buy(company, amnt, price)
                 clear()
-                print(SingleTable([[f"You bought {str(amnt)} of {drug}!"]]).table)
+                print(SingleTable([[f"You bought {str(amnt)} shares of {company}!"]]).table)
                 break
             else:
                 clear()
@@ -489,7 +489,7 @@ def buy_menu(prices, inventory_table, pricing_table, money_table, p):
                 break
 
 def sell_menu(prices, inventory_table, pricing_table, money_table, p):
-    """Allow the player to sell drugs from their inventory."""
+    """Allow the player to sell shares from their inventory."""
 
     while True:
         print(SingleTable(inventory_table()).table)
@@ -497,16 +497,16 @@ def sell_menu(prices, inventory_table, pricing_table, money_table, p):
         print(SingleTable(money_table(), title="Money").table)
         print(SingleTable([["What would you like to sell?"]]).table)
         desired = input("\n> ")
-        if not check_drug_inp(desired):
+        if not check_company_inp(desired):
             clear()
-            print(SingleTable([["Enter the first letter of a drug to choose!"]]).table)
+            print(SingleTable([["Enter the first letter of a company to choose!"]]).table)
         else:
             # Get some useful variables that will clean up the code a lot
-            drug = check_drug_inp(desired)
-            price = round_down(get_price(prices, drug))
-            max_allowed = p.get_max_sell(drug)
+            company = check_company_inp(desired)
+            price = round_down(get_price(prices, company))
+            max_allowed = p.get_max_sell(company)
 
-            print(SingleTable([["How much would you like to sell?"], [f"You have: {str(p.get_amt(drug))} {drug}"]]).table)
+            print(SingleTable([["How much would you like to sell?"], [f"You have: {str(p.get_amt(company))} {company}"]]).table)
             desiredamnt = input("\n> ")
 
             # Calculate amount
@@ -530,15 +530,15 @@ def sell_menu(prices, inventory_table, pricing_table, money_table, p):
                         print(SingleTable([["That isn't a valid amount!"]]).table)
                         continue
 
-            # Sell the drug
-            if p.can_sell(amnt, drug):
-                p.sell(drug, amnt, price)
+            # Sell the company
+            if p.can_sell(amnt, company):
+                p.sell(company, amnt, price)
                 clear()
-                print(SingleTable([[f"You sold {str(amnt)} of {drug}!"]]).table)
+                print(SingleTable([[f"You sold {str(amnt)} shares of {company}!"]]).table)
                 break
             else:
                 clear()
-                print(SingleTable([["You don't have that many drugs!"]]).table)
+                print(SingleTable([["You don't have that many shares!"]]).table)
                 break
 
 def location_menu(p):
@@ -627,11 +627,11 @@ def days_screen():
 def main_screen(p):
     """Main game loop handling actions for the current day."""
 
-    prices = Prices(p)
+    prices = CompanyPrices(p)
     if p.days == p.days_end:
         you_win(p)
     if not p.is_first_round:
-        achoice = choice([lambda p: cops_chase(p), lambda p: buy_gun(p), lambda p: get_mugged(p), lambda p: find_drugs(p), lambda p: upgrade_coat(p)])
+        achoice = choice([lambda p: cops_chase(p), lambda p: buy_gun(p), lambda p: get_mugged(p), lambda p: find_companies(p), lambda p: upgrade_coat(p)])
         achoice(p)
     if prices.action != None and not p.is_first_round:
         print(SingleTable([[prices.action]]).table)

--- a/drugwars/helpers.py
+++ b/drugwars/helpers.py
@@ -32,40 +32,40 @@ def check_ans_yn(a):
     else:
         return 0
 
-def check_drug_inp(a):
-    """Map the user's input to a drug name.
+def check_company_inp(a):
+    """Map the user's input to a company name.
 
     Parameters
     ----------
     a : str
-        Player input representing a drug. Only the first character is used.
+        Player input representing a company. Only the first character is used.
 
     Returns
     -------
     str or None
-        The canonical drug name or ``None`` if the input does not match any
-        known drug.
+        The canonical company name or ``None`` if the input does not match any
+        known company.
 
     Examples
     --------
-    >>> check_drug_inp('c')
-    'cocaine'
-    >>> check_drug_inp('x') is None
+    >>> check_company_inp('c')
+    'acme'
+    >>> check_company_inp('x') is None
     True
     """
 
     a = a.lower()
-    drugs = {
-        "c": "cocaine",
-        "h": "heroin",
-        "a": "acid",
-        "w": "weed",
-        "s": "speed",
-        "l": "ludes",
+    companies = {
+        "a": "acme",
+        "g": "globex",
+        "i": "initech",
+        "u": "umbrella",
+        "c": "cyberdyne",
+        "s": "soylent",
     }
     if len(a) == 0:
         return None
-    for k, v in drugs.items():
+    for k, v in companies.items():
         if k == a[0]:
             return v
     return None
@@ -93,18 +93,18 @@ def round_down(n, decimals=0):
     multiplier = 10 ** decimals
     return int(math.floor(n * multiplier) / multiplier)
 
-def get_price(prices, drug):
-    """Return the price of ``drug`` from a :class:`~drugwars.classes.Prices` instance."""
+def get_price(prices, company):
+    """Return the price of ``company`` from a :class:`~drugwars.classes.CompanyPrices` instance."""
 
-    if drug == "cocaine":
-        return prices.cocaine
-    elif drug == "heroin":
-        return prices.heroin
-    elif drug == "acid":
-        return prices.acid
-    elif drug == "weed":
-        return prices.weed
-    elif drug == "speed":
-        return prices.speed
-    elif drug == "ludes":
-        return prices.ludes
+    if company == "acme":
+        return prices.acme
+    elif company == "globex":
+        return prices.globex
+    elif company == "initech":
+        return prices.initech
+    elif company == "umbrella":
+        return prices.umbrella
+    elif company == "cyberdyne":
+        return prices.cyberdyne
+    elif company == "soylent":
+        return prices.soylent

--- a/tests/test_player_bank.py
+++ b/tests/test_player_bank.py
@@ -10,16 +10,16 @@ from drugwars.helpers import round_down
 
 def test_player_buy_updates_inventory_and_money():
     p = Player()
-    p.buy('weed', 5, 10)
-    assert p.weed == 5
+    p.buy('umbrella', 5, 10)
+    assert p.umbrella == 5
     assert p.money == 2000 - 5 * 10
 
 
 def test_player_sell_updates_inventory_and_money():
     p = Player()
-    p.weed = 8
-    p.sell('weed', 3, 20)
-    assert p.weed == 5
+    p.umbrella = 8
+    p.sell('umbrella', 3, 20)
+    assert p.umbrella == 5
     assert p.money == 2000 + 3 * 20
 
 


### PR DESCRIPTION
## Summary
- rename drug references to company terminology
- update events with corporate-themed text
- change helper utilities accordingly
- adjust tests for new company names

## Testing
- `pip install terminaltables`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851fd8cd5e4832283491b0e1b90e727