### PR TITLE
Refactor player inventory to generic company placeholders

### DIFF
--- a/drugwars/classes.py
+++ b/drugwars/classes.py
@@ -71,12 +71,12 @@ class Stash:
 
     def __init__(self, player):
         self.player = player
-        self.acme = 0
-        self.globex = 0
-        self.initech = 0
-        self.umbrella = 0
-        self.cyberdyne = 0
-        self.soylent = 0
+        self.company_a = 0
+        self.company_b = 0
+        self.company_c = 0
+        self.company_d = 0
+        self.company_e = 0
+        self.company_f = 0
 
     def withdraw(self, company, amount):
         if hasattr(self.player, company):
@@ -119,12 +119,12 @@ class Player:
         self.days_end = 30
         self.health = 20
         self.max_trench = 100
-        self.acme = 0
-        self.globex = 0
-        self.initech = 0
-        self.umbrella = 0
-        self.cyberdyne = 0
-        self.soylent = 0
+        self.company_a = 0
+        self.company_b = 0
+        self.company_c = 0
+        self.company_d = 0
+        self.company_e = 0
+        self.company_f = 0
         self.bank = Bank(self)
         self.stash = Stash(self)
         self.shark = Shark(self)
@@ -137,10 +137,10 @@ class Player:
         self.money -= (amount * price)
 
     def len_inventory(self):
-        return (self.acme + self.globex + self.initech + self.umbrella + self.cyberdyne + self.soylent)
+        return (self.company_a + self.company_b + self.company_c + self.company_d + self.company_e + self.company_f)
 
     def coat_space(self):
-        return self.max_trench - (self.acme + self.globex + self.initech + self.umbrella + self.cyberdyne + self.soylent)
+        return self.max_trench - (self.company_a + self.company_b + self.company_c + self.company_d + self.company_e + self.company_f)
     
     def get_max(self, company, price):
         max_amt = int(round_down(self.money / price))
@@ -150,18 +150,10 @@ class Player:
             return max_amt
 
     def get_max_sell(self, company):
-        if company == 'acme':
-            return self.acme
-        elif company == 'globex':
-            return self.globex
-        elif company == 'initech':
-            return self.initech
-        elif company == 'umbrella':
-            return self.umbrella
-        elif company == 'cyberdyne':
-            return self.cyberdyne
-        elif company == 'soylent':
-            return self.soylent
+        """Return how many shares of ``company`` the player holds."""
+        if hasattr(self, company):
+            return getattr(self, company)
+        return 0
 
     def can_buy(self, price, amount):
         return self.money >= (price * amount) and (self.len_inventory() + amount) <= self.max_trench
@@ -187,24 +179,24 @@ class CompanyPrices:
     def __init__(self, player):
         seed(randint(-10000, 10000))
         self.player = player
-        self.acme = randint(15000, 29999)
-        self.globex = randint(5000, 13999)
-        self.initech = randint(1000, 4999)
-        self.umbrella = randint(300, 899)
-        self.cyberdyne = randint(90, 249)
-        self.soylent = randint(10, 89)
+        self.company_a = randint(15000, 29999)
+        self.company_b = randint(5000, 13999)
+        self.company_c = randint(1000, 4999)
+        self.company_d = randint(300, 899)
+        self.company_e = randint(90, 249)
+        self.company_f = randint(10, 89)
         self.actions = []
         events = [
-            lambda self: self.regulators_probe_acme(),
-            lambda self: self.investors_buy_acme(),
-            lambda self: self.regulators_probe_globex(),
-            lambda self: self.investors_buy_globex(),
-            lambda self: self.cheap_initech(),
-            lambda self: self.cheap_acme(),
-            lambda self: self.cheap_globex(),
-            lambda self: self.cheap_soylent(),
-            lambda self: self.cheap_cyberdyne(),
-            lambda self: self.cheap_umbrella(),
+            lambda self: self.regulators_probe_company_a(),
+            lambda self: self.investors_buy_company_a(),
+            lambda self: self.regulators_probe_company_b(),
+            lambda self: self.investors_buy_company_b(),
+            lambda self: self.cheap_company_c(),
+            lambda self: self.cheap_company_a(),
+            lambda self: self.cheap_company_b(),
+            lambda self: self.cheap_company_f(),
+            lambda self: self.cheap_company_e(),
+            lambda self: self.cheap_company_d(),
         ]
         shuffle(events)
         self.action = None
@@ -218,52 +210,52 @@ class CompanyPrices:
         if len(self.actions) > 0:
             self.action = self.actions[0]
     
-    def regulators_probe_acme(self):
+    def regulators_probe_company_a(self):
         if 1 == randint(1, 35):
-            self.acme *= 2
-            self.actions.append("** Regulators investigated Acme! Shares are rising!! **")
+            self.company_a *= 2
+            self.actions.append("** Regulators investigated Company A! Shares are rising!! **")
 
-    def investors_buy_acme(self):
+    def investors_buy_company_a(self):
         if 1 == randint(1, 35):
-            self.acme *= 4
-            self.actions.append("** Investors are hyped about Acme. Shares are skyrocketing!! **")
+            self.company_a *= 4
+            self.actions.append("** Investors are hyped about Company A. Shares are skyrocketing!! **")
 
-    def regulators_probe_globex(self):
+    def regulators_probe_company_b(self):
         if 1 == randint(1, 25):
-            self.globex *= 2
-            self.actions.append("** Regulators hit Globex headquarters! Shares are rising!!! **")
+            self.company_b *= 2
+            self.actions.append("** Regulators hit Company B headquarters! Shares are rising!!! **")
 
-    def investors_buy_globex(self):
+    def investors_buy_company_b(self):
         if 1 == randint(1, 35):
-            self.globex *= 4
-            self.actions.append("** Traders everywhere want Globex. Shares are skyrocketing!! **")
+            self.company_b *= 4
+            self.actions.append("** Traders everywhere want Company B. Shares are skyrocketing!! **")
     
-    def cheap_initech(self):
+    def cheap_company_c(self):
         if 1 == randint(1, 25):
-            self.initech /= 4
-            self.actions.append("** Initech discovered a cost-cutting breakthrough. Shares are cheap! **")
+            self.company_c /= 4
+            self.actions.append("** Company C discovered a cost-cutting breakthrough. Shares are cheap! **")
     
-    def cheap_soylent(self):
+    def cheap_company_f(self):
         if 1 == randint(1, 20):
-            self.soylent /= 4
-            self.actions.append("** Soylent factory fiasco! Shares are extremely cheap **")
+            self.company_f /= 4
+            self.actions.append("** Company F factory fiasco! Shares are extremely cheap **")
     
-    def cheap_umbrella(self):
+    def cheap_company_d(self):
         if 1 == randint(1, 20):
-            self.umbrella /= 4
-            self.actions.append("** Umbrella giveaway promotion! Shares are practically free! **")
+            self.company_d /= 4
+            self.actions.append("** Company D giveaway promotion! Shares are practically free! **")
 
-    def cheap_globex(self):
+    def cheap_company_b(self):
         if 1 == randint(1, 35):
-            self.globex /= 4
-            self.actions.append("** Globex shares flood the place! Prices have dropped!! **")
+            self.company_b /= 4
+            self.actions.append("** Company B shares flood the place! Prices have dropped!! **")
 
-    def cheap_acme(self):
+    def cheap_company_a(self):
         if 1 == randint(1, 40):
-            self.acme /= 4
-            self.actions.append("** Retro comeback for Acme! Shares are on sale! **")
+            self.company_a /= 4
+            self.actions.append("** Retro comeback for Company A! Shares are on sale! **")
 
-    def cheap_cyberdyne(self):
+    def cheap_company_e(self):
         if 1 == randint(1, 20):
-            self.cyberdyne /= 4
-            self.actions.append("** Cyberdyne expansion stalls. Shares are dropping! **")
+            self.company_e /= 4
+            self.actions.append("** Company E expansion stalls. Shares are dropping! **")

--- a/drugwars/events.py
+++ b/drugwars/events.py
@@ -52,7 +52,7 @@ def cops_chase(player):
                 aout = check_ans_yn(a)
                 if aout == 1:
                     if 1 == randint(1,3):
-                        company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                        company = choice(["company_a", "company_b", "company_c", "company_d", "company_e", "company_f"])
                         pc = player.get_amt(company)
                         if pc > 0:
                             amnt = randint(1, 10)
@@ -69,7 +69,7 @@ def cops_chase(player):
                             clear()
                             print(SingleTable([["You got hit by one of their shots and lost some health!"]]).table)
                         else:
-                            company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                            company = choice(["company_a", "company_b", "company_c", "company_d", "company_e", "company_f"])
                             pc = player.get_amt(company)
                             if pc > 0:
                                 amnt = randint(1, 10)
@@ -84,7 +84,7 @@ def cops_chase(player):
                     if 1 == randint(1,6):
                         cops -= 1
                         if cops == 0:
-                            company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                            company = choice(["company_a", "company_b", "company_c", "company_d", "company_e", "company_f"])
                             pc = player.get_amt(company)
                             if pc > 0:
                                 amnt = randint(1, 10)
@@ -106,7 +106,7 @@ def cops_chase(player):
                 print(SingleTable([["Press ENTER to Try and Run"], ["HP: " + str(player.health) + "/ 20"]]).table)
                 input()
                 if 1 == randint(1,3):
-                    company = choice(["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"])
+                    company = choice(["company_a", "company_b", "company_c", "company_d", "company_e", "company_f"])
                     pc = player.get_amt(company)
                     if pc > 0:
                         amnt = randint(1, 10)
@@ -177,7 +177,7 @@ def ask_stash(player):
 def visit_stash(player):
     """Interactively deposit to or withdraw shares from the stash."""
 
-    stashes = ["acme", "globex", "initech", "umbrella", "cyberdyne", "soylent"]
+    stashes = ["company_a", "company_b", "company_c", "company_d", "company_e", "company_f"]
     for stash in stashes:
         clear()
         while True:
@@ -365,23 +365,23 @@ def find_companies(p):
         cstr = ""
         if p.len_inventory() + amnt <= p.max_trench:
             if choice_num == 1:
-                cstr = "Acme"
-                p.acme += amnt
+                cstr = "Company A"
+                p.company_a += amnt
             if choice_num == 2:
-                cstr = "Globex"
-                p.globex += amnt
+                cstr = "Company B"
+                p.company_b += amnt
             if choice_num == 3:
-                cstr = "Initech"
-                p.initech += amnt
+                cstr = "Company C"
+                p.company_c += amnt
             if choice_num == 4:
-                cstr = "Umbrella"
-                p.umbrella += amnt
+                cstr = "Company D"
+                p.company_d += amnt
             if choice_num == 5:
-                cstr = "Cyberdyne"
-                p.cyberdyne += amnt
+                cstr = "Company E"
+                p.company_e += amnt
             if choice_num == 6:
-                cstr = "Soylent"
-                p.soylent += amnt
+                cstr = "Company F"
+                p.company_f += amnt
             print(SingleTable([["You found " + str(amnt) + " shares of " + cstr + " on the ground... \n NICE"]]).table)
             input("Press ENTER to Continue")
 
@@ -646,15 +646,15 @@ def main_screen(p):
         clear()
         inventory_table = lambda : [
             ['Inventory', 'Days Left: ' + str(p.days_end - p.days)],
-            ['Cocaine: ' + str(round_down(p.cocaine)), 'Weed: ' + str(round_down(p.weed))],
-            ['Heroin: ' + str(round_down(p.heroin)), 'Speed: ' + str(round_down(p.speed))],
-            ['Acid: ' + str(round_down(p.acid)), 'Ludes: ' + str(round_down(p.ludes))],
+            ['Company A: ' + str(round_down(p.company_a)), 'Company B: ' + str(round_down(p.company_b))],
+            ['Company C: ' + str(round_down(p.company_c)), 'Company D: ' + str(round_down(p.company_d))],
+            ['Company E: ' + str(round_down(p.company_e)), 'Company F: ' + str(round_down(p.company_f))],
         ]
         pricing_table = lambda : [
             ['Current Area: ' + p.current_area, 'Coat Space: ' + str(p.coat_space()) + " / " + str(p.max_trench)],
-            ['Cocaine: ' + str(round_down(prices.cocaine)), 'Weed: ' + str(round_down(prices.weed))],
-            ['Heroin: ' + str(round_down(prices.heroin)), 'Speed: ' + str(round_down(prices.speed))],
-            ['Acid: ' + str(round_down(prices.acid)), 'Ludes: ' + str(round_down(prices.ludes))]
+            ['Company A: ' + str(round_down(prices.company_a)), 'Company B: ' + str(round_down(prices.company_b))],
+            ['Company C: ' + str(round_down(prices.company_c)), 'Company D: ' + str(round_down(prices.company_d))],
+            ['Company E: ' + str(round_down(prices.company_e)), 'Company F: ' + str(round_down(prices.company_f))]
         ]
         money_table = lambda : [
             ['Debt: ' + str(int(round_down(p.shark.balance))) ,'Guns: ' + str(p.guns), 'Bank: ' + str(int(round_down(p.bank.balance))), 'Wallet: ' + str(int(round_down(p.money)))]

--- a/drugwars/helpers.py
+++ b/drugwars/helpers.py
@@ -48,20 +48,20 @@ def check_company_inp(a):
 
     Examples
     --------
-    >>> check_company_inp('c')
-    'acme'
+    >>> check_company_inp('a')
+    'company_a'
     >>> check_company_inp('x') is None
     True
     """
 
     a = a.lower()
     companies = {
-        "a": "acme",
-        "g": "globex",
-        "i": "initech",
-        "u": "umbrella",
-        "c": "cyberdyne",
-        "s": "soylent",
+        "a": "company_a",
+        "b": "company_b",
+        "c": "company_c",
+        "d": "company_d",
+        "e": "company_e",
+        "f": "company_f",
     }
     if len(a) == 0:
         return None
@@ -96,15 +96,15 @@ def round_down(n, decimals=0):
 def get_price(prices, company):
     """Return the price of ``company`` from a :class:`~drugwars.classes.CompanyPrices` instance."""
 
-    if company == "acme":
-        return prices.acme
-    elif company == "globex":
-        return prices.globex
-    elif company == "initech":
-        return prices.initech
-    elif company == "umbrella":
-        return prices.umbrella
-    elif company == "cyberdyne":
-        return prices.cyberdyne
-    elif company == "soylent":
-        return prices.soylent
+    if company == "company_a":
+        return prices.company_a
+    elif company == "company_b":
+        return prices.company_b
+    elif company == "company_c":
+        return prices.company_c
+    elif company == "company_d":
+        return prices.company_d
+    elif company == "company_e":
+        return prices.company_e
+    elif company == "company_f":
+        return prices.company_f

--- a/tests/test_player_bank.py
+++ b/tests/test_player_bank.py
@@ -10,16 +10,16 @@ from drugwars.helpers import round_down
 
 def test_player_buy_updates_inventory_and_money():
     p = Player()
-    p.buy('umbrella', 5, 10)
-    assert p.umbrella == 5
+    p.buy('company_d', 5, 10)
+    assert p.company_d == 5
     assert p.money == 2000 - 5 * 10
 
 
 def test_player_sell_updates_inventory_and_money():
     p = Player()
-    p.umbrella = 8
-    p.sell('umbrella', 3, 20)
-    assert p.umbrella == 5
+    p.company_d = 8
+    p.sell('company_d', 3, 20)
+    assert p.company_d == 5
     assert p.money == 2000 + 3 * 20
 
 


### PR DESCRIPTION
## Summary
- rename company attributes to `company_a`..`company_f`
- update helper functions to map new company placeholders
- adjust events to grant and track generic companies
- revise tests to use new attribute names

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852288e18e88322935a1771735b24dd