### PR TITLE
Fix forward references

### DIFF
--- a/stockwolf/agents/__init__.py
+++ b/stockwolf/agents/__init__.py
@@ -1,1 +1,2 @@
 
+from __future__ import annotations

--- a/stockwolf/agents/company.py
+++ b/stockwolf/agents/company.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .player import Player
 
 @dataclass
 class Company:

--- a/stockwolf/agents/country.py
+++ b/stockwolf/agents/country.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Dict, Any
+from typing import Dict, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .market import Market
 
 @dataclass
 class CountryAgent:

--- a/stockwolf/agents/market.py
+++ b/stockwolf/agents/market.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Dict
 

--- a/stockwolf/agents/player.py
+++ b/stockwolf/agents/player.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .company import Company
+    from .market import Market
 
 @dataclass
 class Player:

--- a/stockwolf/engine/simulation.py
+++ b/stockwolf/engine/simulation.py
@@ -1,6 +1,11 @@
-from typing import List
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
 from ..agents.country import CountryAgent
 from ..agents.market import Market
+
+if TYPE_CHECKING:
+    from ..agents.player import Player
 
 class Simulation:
     def __init__(self, countries: List[CountryAgent], market: Market, players: List['Player']):


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations for agent modules
- avoid F821 errors by importing forward ref types with `TYPE_CHECKING`

## Testing
- `flake8 --select F821 stockwolf/agents stockwolf/engine/simulation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68522f4bfba88322bca22ef8d1d91bb1