### PR TITLE
Add official market data with country-based pricing

### DIFF
--- a/stockwolf/agents/company.py
+++ b/stockwolf/agents/company.py
@@ -12,6 +12,7 @@ class Company:
     ticker: str
     share_price: float
     dividend_yield: float = 0.0
+    country: str | None = None
 
     def pay_dividend(self, player: 'Player') -> float:
         """Return dividend amount for one share."""

--- a/stockwolf/agents/country.py
+++ b/stockwolf/agents/country.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Any, TYPE_CHECKING
+import random
 
 if TYPE_CHECKING:
     from .market import Market
@@ -21,3 +22,6 @@ class CountryAgent:
         # interest_rate could affect company share prices globally
         for company in market.companies.values():
             company.share_price *= 1 + (self.interest_rate - 0.05) * 0.01
+            if getattr(company, 'country', None) == self.name:
+                # home market polarization effect
+                company.share_price *= random.choice([1.05, 0.95])

--- a/stockwolf/agents/player.py
+++ b/stockwolf/agents/player.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, TYPE_CHECKING
+import random
 
 if TYPE_CHECKING:
     from .company import Company
@@ -19,10 +20,14 @@ class Player:
             self.cash -= cost
             self.portfolio[company.ticker] = self.portfolio.get(company.ticker, 0) + quantity
 
-    def sell(self, company: 'Company', quantity: int) -> None:
+    def sell(self, company: 'Company', quantity: int, market_country: str | None = None) -> None:
         if self.portfolio.get(company.ticker, 0) >= quantity:
             self.portfolio[company.ticker] -= quantity
-            self.cash += company.share_price * quantity
+            price = company.share_price
+            if market_country and company.country and market_country == company.country:
+                # Polarize price when trading in the country of origin
+                price *= random.choice([1.1, 0.9])
+            self.cash += price * quantity
 
     def value(self, market: 'Market') -> float:
         total = self.cash

--- a/stockwolf/data/official.yaml
+++ b/stockwolf/data/official.yaml
@@ -1,0 +1,212 @@
+# Official countries and companies derived from README.md
+countries:
+  - name: Mexico
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Petróleos Unidos del Pueblo'
+        ticker: PUP
+        share_price: 100
+        dividend_yield: 0.02
+        country: Mexico
+      - name: 'Comercializadora Azteca de Paguitos'
+        ticker: CAP
+        share_price: 90
+        dividend_yield: 0.02
+        country: Mexico
+  - name: Cuba
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Servicios Médicos Internacionales de la Patria'
+        ticker: SMIP
+        share_price: 95
+        dividend_yield: 0.02
+        country: Cuba
+      - name: 'Cañaverales Unidos de la Revolución'
+        ticker: CUR
+        share_price: 85
+        dividend_yield: 0.02
+        country: Cuba
+  - name: 'EE.UU.'
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'FreedomCloud Defense Systems'
+        ticker: FCDS
+        share_price: 120
+        dividend_yield: 0.03
+        country: 'EE.UU.'
+      - name: 'McCapital Unlimited Inc.'
+        ticker: MCUI
+        share_price: 110
+        dividend_yield: 0.03
+        country: 'EE.UU.'
+  - name: Brasil
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Samba Agroexportadora Integrada'
+        ticker: SAI
+        share_price: 80
+        dividend_yield: 0.02
+        country: Brasil
+      - name: 'Minerales & Carnaval Sociedad Anónima'
+        ticker: MiCaSA
+        share_price: 75
+        dividend_yield: 0.02
+        country: Brasil
+  - name: India
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'CastaTech Solutions Pvt. Ltd.'
+        ticker: CTSP
+        share_price: 90
+        dividend_yield: 0.02
+        country: India
+      - name: 'Bharata Holdings of Ancestral Wealth'
+        ticker: BHAW
+        share_price: 85
+        dividend_yield: 0.02
+        country: India
+  - name: Rusia
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'GazComPriv Export JSC'
+        ticker: GCPE
+        share_price: 100
+        dividend_yield: 0.02
+        country: Rusia
+      - name: 'SberFuture Artificial Stability'
+        ticker: SFAS
+        share_price: 95
+        dividend_yield: 0.02
+        country: Rusia
+  - name: China
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Pueblo Digital Unificado S.A.'
+        ticker: PDU
+        share_price: 110
+        dividend_yield: 0.02
+        country: China
+      - name: 'Dragón Celeste de Infraestructura Estatal'
+        ticker: DCIE
+        share_price: 100
+        dividend_yield: 0.02
+        country: China
+  - name: Argentina
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Alfajores Bursátiles del Sur S.A.'
+        ticker: ABS
+        share_price: 70
+        dividend_yield: 0.02
+        country: Argentina
+      - name: 'Litio Emocional Sociedad Anónima'
+        ticker: LESA
+        share_price: 80
+        dividend_yield: 0.02
+        country: Argentina
+  - name: Alemania
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Ordnung Maschinenbau AG'
+        ticker: OMA
+        share_price: 105
+        dividend_yield: 0.03
+        country: Alemania
+      - name: 'Banco Federal de Precisión Financiera'
+        ticker: BFPF
+        share_price: 100
+        dividend_yield: 0.03
+        country: Alemania
+  - name: Japón
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Nippon Kikai Zen Corporation'
+        ticker: NKZC
+        share_price: 100
+        dividend_yield: 0.02
+        country: Japón
+      - name: 'Sakura Neuralware Co.'
+        ticker: SNC
+        share_price: 95
+        dividend_yield: 0.02
+        country: Japón
+  - name: Sudáfrica
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'PanMinerals SA Holdings Ltd.'
+        ticker: PMSA
+        share_price: 90
+        dividend_yield: 0.02
+        country: Sudáfrica
+      - name: 'Ubuntu Energy Transition Inc.'
+        ticker: UETI
+        share_price: 85
+        dividend_yield: 0.02
+        country: Sudáfrica
+  - name: 'Arabia Saudita'
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Desierto Profundo Petroleros Ltd.'
+        ticker: DPPL
+        share_price: 110
+        dividend_yield: 0.02
+        country: 'Arabia Saudita'
+      - name: 'Peregrinaje Global de Servicios Hajj'
+        ticker: PGSH
+        share_price: 90
+        dividend_yield: 0.02
+        country: 'Arabia Saudita'
+  - name: Singapur
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Capitales Compactos Asia Pte. Ltd.'
+        ticker: CCAP
+        share_price: 100
+        dividend_yield: 0.02
+        country: Singapur
+      - name: 'Red Financiera Transoceánica'
+        ticker: RFT
+        share_price: 95
+        dividend_yield: 0.02
+        country: Singapur
+  - name: Suiza
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Fondo Eterno de Patrimonio Silente'
+        ticker: FEPS
+        share_price: 115
+        dividend_yield: 0.03
+        country: Suiza
+      - name: 'Custodia Alpina Unificada SA'
+        ticker: CAUSA
+        share_price: 110
+        dividend_yield: 0.03
+        country: Suiza
+  - name: 'Corea del Sur'
+    tax_rate: 0.2
+    interest_rate: 0.05
+    companies:
+      - name: 'Tecnología Orientada al Consenso'
+        ticker: TOC
+        share_price: 105
+        dividend_yield: 0.02
+        country: 'Corea del Sur'
+      - name: 'SeoulQuantum Industrial Holdings'
+        ticker: SQIH
+        share_price: 100
+        dividend_yield: 0.02
+        country: 'Corea del Sur'

--- a/stockwolf/main.py
+++ b/stockwolf/main.py
@@ -16,7 +16,10 @@ def build_world(data):
     market = Market()
     countries = []
     for cdata in data['countries']:
-        comps = [Company(**comp) for comp in cdata.get('companies', [])]
+        comps = []
+        for comp_data in cdata.get('companies', []):
+            comp_data.setdefault('country', cdata['name'])
+            comps.append(Company(**comp_data))
         country = CountryAgent(name=cdata['name'], tax_rate=cdata['tax_rate'], interest_rate=cdata['interest_rate'])
         for comp in comps:
             market.list_company(comp)
@@ -26,7 +29,7 @@ def build_world(data):
 
 
 def main(path: str = None):
-    path = Path(path or Path(__file__).resolve().parent / 'data' / 'sample.yaml')
+    path = Path(path or Path(__file__).resolve().parent / 'data' / 'official.yaml')
     data = load_data(path)
     countries, market, players = build_world(data)
     sim = Simulation(countries, market, players)


### PR DESCRIPTION
## Summary
- load official dataset of countries and companies
- include country attribute in Company
- adjust player selling to polarize prices when trading domestically
- apply home-market effect in country policy
- new `official.yaml` with all countries and companies from README

## Testing
- `pip install terminaltables`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685230a7f25c832289f2a90b07226131