### PR TITLE
Fix explicit imports in __main__

### DIFF
--- a/agentics/__main__.py
+++ b/agentics/__main__.py
@@ -1,4 +1,5 @@
-from agentics.events import *
+from terminaltables import SingleTable
+from agentics.events import clear, difficulty_screen, days_screen, main_screen
 from agentics.classes import Player
 
 def main():


### PR DESCRIPTION
## Summary
- avoid wildcard import from agentics.events
- import needed names directly
- ensure that running `python -m agentics` still works

## Testing
- `timeout 1 python -m agentics > /tmp/out.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685231eecba88322b6d8c6d18eadea31