### PR TITLE
Add flake8 linting and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run flake8
+        run: flake8
+      - name: Run tests
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 terminaltables==3.1.0
 pytest>=6.0
 pyyaml
+flake8
 


### PR DESCRIPTION
## Summary
- add flake8 to requirements
- create GitHub Actions workflow running flake8 and pytest

## Testing
- `pytest -q`
- `flake8 | head` *(fails: various style errors)*

------
https://chatgpt.com/codex/tasks/task_b_68541d6ddd2483229544cfb497ea61ca