### PR TITLE
Add game loop integration with simulation

### DIFF
--- a/agentics/events.py
+++ b/agentics/events.py
@@ -722,4 +722,6 @@ def main_screen(p):
     p.is_first_round = False
     p.bank.interest()
     p.shark.interest()
-    main_screen(p)
+    # Return control to the caller so external loops can advance the
+    # simulation or perform other logic before showing the menu again.
+    return

--- a/integration/game_loop.py
+++ b/integration/game_loop.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+from terminaltables import SingleTable
+
+from agentics.events import clear, difficulty_screen, days_screen, main_screen
+from agentics.classes import Player
+from stockwolf.main import load_data, build_world
+from stockwolf.engine.simulation import Simulation
+
+
+def load_world(path: Path | None = None):
+    """Load countries and market using StockWolf data."""
+    data_path = path or Path(__file__).resolve().parents[1] / "stockwolf" / "data" / "official.yaml"
+    data = load_data(data_path)
+    countries, market, _ = build_world(data)
+    return countries, market
+
+
+def run(data_path: str | Path | None = None) -> None:
+    """Run the integrated StockWolf/agentics game loop."""
+    clear()
+    try:
+        logo = """\
+           ___  ___  __  _______
+          / _ \/ _ \/ / / / ___/
+         / // / , _/ /_/ / (_ /
+        /____/_/|_|\____/\___/  ___
+           | | /| / / _ | / _ \/ __/
+           | |/ |/ / __ |/ , _/\ \
+           |__/|__/_/ |_/_/|_/___/"""
+        title_screen = [
+            [logo],
+            ["        Created by Max Bridgland"],
+            ["     Based on the DOS Game of the 80s"],
+            [""],
+            ["   Press ENTER to Play or Ctrl+C to Quit"],
+            [""],
+            ["  Version: 1.2.1  Report Bugs on GitHub"],
+            ["https://github.com/M4cs/Drugwars/issues/new"],
+        ]
+        print(SingleTable(title_screen).table)
+        input()
+
+        player = Player()
+        clear()
+        diff = difficulty_screen()
+        if diff == 0:
+            player.shark.balance = 5500
+        elif diff == 1:
+            player.shark.balance = 6500
+        elif diff == 2:
+            player.shark.balance = 8000
+
+        player.days_end = days_screen()
+
+        countries, market = load_world(Path(data_path) if data_path else None)
+        sim = Simulation(countries, market, [player])
+
+        while True:
+            main_screen(player)
+            sim.tick()
+    except KeyboardInterrupt:
+        exit()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- stop recursion in `agentics.events.main_screen` so it returns after one day
- add `integration/game_loop.py` that runs StockWolf's `Simulation` alongside the agentics menus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685426316fcc8322a4564aa5dd0bf55a