### PR TITLE
Add YAML path option and new game entry

### DIFF
--- a/integration/game_loop.py
+++ b/integration/game_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import argparse
 from terminaltables import SingleTable
 
 from agentics.events import clear, difficulty_screen, days_screen, main_screen
@@ -64,5 +65,13 @@ def run(data_path: str | Path | None = None) -> None:
         exit()
 
 
+def cli() -> None:
+    """Entry point for the console script."""
+    parser = argparse.ArgumentParser(description="Run StockWolf agentics game")
+    parser.add_argument("--yaml", "-y", type=Path, help="Path to YAML world file")
+    args = parser.parse_args()
+    run(args.yaml)
+
+
 if __name__ == "__main__":
-    run()
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     entry_points={
         'console_scripts': [
             'agentics = agentics.__main__:main',
-            'stockwolf = stockwolf.main:main'
+            'stockwolf = stockwolf.main:cli',
+            'stockwolf-game = integration.game_loop:cli'
         ],
     },
     classifiers=[  # Used by PyPI to classify the project and make it searchable

--- a/stockwolf/main.py
+++ b/stockwolf/main.py
@@ -1,3 +1,4 @@
+import argparse
 import yaml
 from .agents.country import CountryAgent
 from .agents.company import Company
@@ -28,7 +29,7 @@ def build_world(data):
     return countries, market, [player]
 
 
-def main(path: str = None):
+def main(path: str | Path | None = None) -> None:
     path = Path(path or Path(__file__).resolve().parent / 'data' / 'official.yaml')
     data = load_data(path)
     countries, market, players = build_world(data)
@@ -38,5 +39,13 @@ def main(path: str = None):
     print(f"Player value: {players[0].value(market):.2f}")
 
 
+def cli() -> None:
+    """Entry point for console script."""
+    parser = argparse.ArgumentParser(description="Run StockWolf simulation")
+    parser.add_argument("--yaml", "-y", type=Path, help="Path to YAML world file")
+    args = parser.parse_args()
+    main(args.yaml)
+
+
 if __name__ == '__main__':
-    main()
+    cli()


### PR DESCRIPTION
## Summary
- add argparse-based CLI runner for StockWolf
- add CLI for hybrid `stockwolf-game`
- expose YAML file argument in both entry points

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685427393f308322a714ddeea2855100