### PR TITLE
Add basic agent dataclasses

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -89,4 +89,30 @@ class CountryAgent:
             if getattr(company, 'country', None) == self.name:
                 company.share_price *= random.choice([1.05, 0.95])
 
-__all__ = ['Player', 'Company', 'Market', 'CountryAgent']
+
+@dataclass
+class RegulatorAgent:
+    name: str = 'Regulator'
+    power: float = 1.0
+
+
+@dataclass
+class BankAgent:
+    name: str = 'Bank'
+    funds: float = 1_000_000.0
+
+
+@dataclass
+class PlayerAgent:
+    name: str = 'Bot'
+    funds: float = 5000.0
+
+__all__ = [
+    'Player',
+    'Company',
+    'Market',
+    'CountryAgent',
+    'RegulatorAgent',
+    'BankAgent',
+    'PlayerAgent',
+]

--- a/stockwolf/agents/__init__.py
+++ b/stockwolf/agents/__init__.py
@@ -1,2 +1,20 @@
 
 from __future__ import annotations
+
+from .player import Player
+from .company import Company
+from .market import Market
+from .country import CountryAgent
+from .regulator import RegulatorAgent
+from .bank import BankAgent
+from .player_agent import PlayerAgent
+
+__all__ = [
+    'Player',
+    'Company',
+    'Market',
+    'CountryAgent',
+    'RegulatorAgent',
+    'BankAgent',
+    'PlayerAgent',
+]

--- a/stockwolf/agents/bank.py
+++ b/stockwolf/agents/bank.py
@@ -1,0 +1,3 @@
+from common import BankAgent
+
+__all__ = ['BankAgent']

--- a/stockwolf/agents/player_agent.py
+++ b/stockwolf/agents/player_agent.py
@@ -1,0 +1,3 @@
+from common import PlayerAgent
+
+__all__ = ['PlayerAgent']

--- a/stockwolf/agents/regulator.py
+++ b/stockwolf/agents/regulator.py
@@ -1,0 +1,3 @@
+from common import RegulatorAgent
+
+__all__ = ['RegulatorAgent']

--- a/tests/test_agents_defaults.py
+++ b/tests/test_agents_defaults.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from stockwolf.agents.regulator import RegulatorAgent
+from stockwolf.agents.bank import BankAgent
+from stockwolf.agents.player_agent import PlayerAgent
+
+
+def test_regulator_defaults():
+    agent = RegulatorAgent()
+    assert agent.name == 'Regulator'
+    assert agent.power == 1.0
+
+
+def test_bank_defaults():
+    agent = BankAgent()
+    assert agent.name == 'Bank'
+    assert agent.funds == 1_000_000.0
+
+
+def test_player_agent_defaults():
+    agent = PlayerAgent()
+    assert agent.name == 'Bot'
+    assert agent.funds == 5000.0


### PR DESCRIPTION
## Summary
- add RegulatorAgent, BankAgent and PlayerAgent dataclasses
- expose new classes via stockwolf.agents with thin wrapper modules
- test defaults for the new agents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685593523cb883229ea46c3f183bfd37